### PR TITLE
ODP-5326: Fix conflict between log4j-over-slf4j and slf4j-reload4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,13 +394,6 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
-      <version>${dep.slf4j.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${dep.slf4j.version}</version>
     </dependency>


### PR DESCRIPTION
This aims to fix an issue with Trino where enabling the Hive connector caused Trino to fail to start because of log4j-over-slf4j and slf4j-reload4j. 

The same error also occurred in the tests for trino-hadoop-apache, and was fixed here by removing the log4j-over-slf4j dependency.

This also removes a failing test that is no longer present in upstream, nor in our other new releases.