### PR TITLE
ODP-6944: Bump Jackson to 2.18.6 for Hadoop 3.2.3.7-2 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
     <dep.slf4j.version>1.7.36</dep.slf4j.version>
     <dep.hadoop.version>3.2.3.3.2.3.7-2</dep.hadoop.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
-    <jackson2.version>2.16.1</jackson2.version>
-    <jackson2.databind.version>2.16.1</jackson2.databind.version>
+    <jackson2.version>2.18.6</jackson2.version>
+    <jackson2.databind.version>2.18.6</jackson2.databind.version>
   </properties>
 
   <!-- Resolving hadoop-common conflicts with common-compress version -->


### PR DESCRIPTION
This has been tested locally